### PR TITLE
[lugbot] Added portalPropertiesPaths to Lugbot configuration file.

### DIFF
--- a/.liferay/lugbot.yaml
+++ b/.liferay/lugbot.yaml
@@ -20,3 +20,10 @@ tasks:
     - name: upgrade-portal-properties
     - name: cfg-to-config-file
     workspacePath: liferay-workspace/
+portalPropertiesPaths:
+#  - liferay-workspace/configs/dev/portal-ext.properties
+#  - liferay-workspace/configs/prod/portal-ext.properties
+#  - liferay-workspace/configs/local/portal-ext.properties
+#  - liferay-workspace/configs/uat/portal-ext.properties
+#  - liferay-workspace/modules/evp/evp-portlet/src/main/java/portal.properties
+#  - liferay-plugins-sdk-6.2-ee-sp20/portlets/evp-portlet/docroot/WEB-INF/src/portal.properties


### PR DESCRIPTION
### Lugbot has created this PR to add a portalPropertiesPaths setting in Lugbot config file.
![merge advice](https://img.shields.io/badge/merge%20advice-recommended-orange)

<p>In order for Lugbot to help with upgrading portal properties, the location of portal-*.properties files must be specified. Here is an example <code>.liferay/lugbot.yaml</code> file.</p> <pre><code>currentVersion: "6.2"
upgradeVersion: "7.3"
workspacePath: "liferay-workspace/"
portalPropertiesPath:
  - "configs/qa/portal-ext.env.properties"
  - "configs/dev/portal-ext.env.properties"
  - "configs/common/portal-ext.properties"
</code></pre><p>When you specify a portalPropertiesPath as shown above, Lugbot will scan that properties file and analyze those properties and report which ones must be upgraded along with advice for how to perform the upgrade. Here is a sample report of Lugbot’s analysis.</p> <pre><code>**Properties to review in configs/prod/portal-ext.properties:**
index.read.only
	MODULARIZE AS OSGI - This property matches with the following OSGI config, select the most appropriate:
		- suppressIndexReadOnly from com.liferay.portal.search.internal.index.IndexStatusManagerInternalConfiguration

custom.property
	ANALYZE - No Liferay property, check if you still need it

breadcrumb.display.style.default
	MODULARIZE AS OSGI - Use ddmTemplateKeyDefault in com.liferay.site.navigation.breadcrumb.web.internal.configuration.SiteNavigationBreadcrumbWebTemplateConfiguration. More information at Breaking Changes for Liferay 7: https://dev.liferay.com/develop/reference/-/knowledge_base/7-0/breaking-changes#replaced-the-breadcrumb-portlets-display-styles-with-adts

buffered.increment.enabled
	ANALYZE - This property is not present in thew new portal.properties. Check if you still need it or check the documentation to find a replacement

**Properties to review in configs/uat/portal-ext.properties:**
index.read.only
	MODULARIZE AS OSGI - This property matches with the following OSGI config, select the most appropriate:
		- suppressIndexReadOnly from com.liferay.portal.search.internal.index.IndexStatusManagerInternalConfiguration

custom.property
	ANALYZE - No Liferay property, check if you still need it
</code></pre> 

---

:information_source: The upgrades provided in this PR will not be tried again until the branch upgradeCheckpoint is deleted.